### PR TITLE
Added leader election and consensus

### DIFF
--- a/src/comunication/ComunicationInterface.java
+++ b/src/comunication/ComunicationInterface.java
@@ -1,0 +1,9 @@
+package comunication;
+
+import java.io.IOException;
+
+public interface ComunicationInterface {
+  void sendMessage(String address, Integer port, String message) throws IOException;
+  String listenMulticastMessage(String address, Integer port) throws IOException;
+  String listenUnicastMessage(Integer port) throws IOException;
+}

--- a/src/comunication/UDPInterface.java
+++ b/src/comunication/UDPInterface.java
@@ -1,8 +1,0 @@
-package comunication;
-
-import java.io.IOException;
-
-public interface UDPInterface {
-  void sendMessage(String address, Integer port, String message) throws IOException;
-  void listenNewHosts(String address, Integer port) throws IOException;
-}

--- a/src/consensus/ConsensusRole.java
+++ b/src/consensus/ConsensusRole.java
@@ -1,0 +1,5 @@
+package consensus;
+
+public enum ConsensusRole {
+  FOLLOWER, CANDIDATE, LEADER
+}

--- a/src/main/RMIServer.java
+++ b/src/main/RMIServer.java
@@ -5,6 +5,8 @@ import java.net.InetAddress;
 import java.rmi.RemoteException;
 import java.rmi.registry.LocateRegistry;
 import java.rmi.registry.Registry;
+import java.util.ArrayList;
+import consensus.ConsensusRole;
 import places.PlaceManager;
 
 public class RMIServer {
@@ -15,19 +17,19 @@ public class RMIServer {
 
     PlaceManager placeList = startRMIServer(serverPort);
 
-    
+    // Handles sending all multicast messages
     new Thread() {
       public void run() {
         while (true) {
           // Sends own IP in Multicast
           try {
             placeList.sendMessage(multicastAddress, multicastPort,
-                "rmi://" + InetAddress.getLocalHost().getHostAddress() + ":" + serverPort + "/placelist");
+                InetAddress.getLocalHost().getHostAddress() + ":" + serverPort);
           } catch (IOException e) {
             System.out.println(e.getMessage());
           }
-          
-          // Holds for X milliseconds
+
+          // Holds for 10 seconds
           try {
             Thread.sleep(10000);
           } catch (InterruptedException e) {
@@ -36,14 +38,68 @@ public class RMIServer {
         }
       }
     }.start();
-   
+
+    // Clears all replicas every 15s
+    new Thread() {
+      public void run() {
+        while (true) {
+          try {
+            placeList.removeAllReplicas();
+          } catch (RemoteException e) {
+            System.out.println(e.getMessage());
+          }
+
+          // Holds for 15 seconds
+          try {
+            Thread.sleep(15000);
+          } catch (InterruptedException e) {
+            System.out.println(e.getMessage());
+          }
+        }
+      }
+    }.start();
+
+    // Handles listening to multicast messages
     new Thread() {
       public void run() {
         // Listens to other IPs in Multicast
-        try {
-          placeList.listenNewHosts(multicastAddress, multicastPort);
-        } catch (IOException e) {
-          System.out.println(e.getMessage());
+        while (true) {
+          try {
+            String replicaAddress =
+                placeList.listenMulticastMessage(multicastAddress, multicastPort);
+            placeList.addReplica(replicaAddress);
+          } catch (IOException e) {
+            System.out.println(e.getMessage());
+          }
+        }
+      }
+    }.start();
+
+    // Handles consensus
+    new Thread() {
+      public void run() {
+        while (true) {
+          ConsensusRole current = placeList.getRole();
+
+          if (current == ConsensusRole.LEADER) {
+            System.out.println(current);
+            consensusLeader(placeList);
+
+            // Holds for 1 second
+            try {
+              Thread.sleep(1000);
+            } catch (InterruptedException e) {
+              System.out.println(e.getMessage());
+            }
+
+          } else if (current == ConsensusRole.CANDIDATE) {
+            System.out.println(current);
+            consensusCandidate(placeList);
+
+          } else {
+            System.out.println(current);
+            consensusFollower(placeList);
+          }
         }
       }
     }.start();
@@ -76,5 +132,128 @@ public class RMIServer {
     }
 
     return placeList;
+  }
+
+  private static void consensusLeader(PlaceManager placeList) {
+    // Sends Unicast Message to all replicas
+    ArrayList<String> replicas = placeList.getReplicas();
+    for (String address : replicas) {
+      // Splits full address (host:port)
+      String[] fullAddress = address.split(":");
+      String host = fullAddress[0];
+      Integer port = Integer.parseInt(fullAddress[1]);
+
+      // Sends own address labeled as leader
+      try {
+        placeList.sendMessage(host, port, "leader," + InetAddress.getLocalHost().getHostAddress()
+            + ":" + placeList.getServerPort());
+      } catch (IOException e) {
+        System.out.println(e.getMessage());
+      }
+    }
+  }
+
+  private static void consensusCandidate(PlaceManager placeList) {
+    new Thread() {
+      public void run() {
+        // Sends Unicast Message to all replicas
+        ArrayList<String> replicas = placeList.getReplicas();
+        for (String address : replicas) {
+          // Splits full address (host:port)
+          String[] fullAddress = address.split(":");
+          String host = fullAddress[0];
+          Integer port = Integer.parseInt(fullAddress[1]);
+
+          // Sends own address labeled as candidate
+          try {
+            placeList.sendMessage(host, port, "candidate,"
+                + InetAddress.getLocalHost().getHostAddress() + ":" + placeList.getServerPort());
+          } catch (IOException e) {
+            System.out.println(e.getMessage());
+          }
+        }
+
+      }
+    }.start();
+
+    Integer numberVotes = 1;
+    // While numberVotes is not majority
+    ArrayList<String> replicas = placeList.getReplicas();
+    while (numberVotes < replicas.size() / 2) {
+      try {
+        // Gets message and splits it on ","
+        String[] message = placeList.listenUnicastMessage(placeList.getServerPort()).split(",");
+
+        if (message[0].equals("leader")) {
+          // New leader was found before
+          placeList.setRole(ConsensusRole.FOLLOWER);
+          return;
+        }
+
+        if (message[0].equals("vote")) {
+          // New vote received
+          numberVotes++;
+        }
+      } catch (IOException e) {
+        System.out.println(e.getMessage());
+      }
+    }
+
+    // New Leader!
+    placeList.setRole(ConsensusRole.LEADER);
+  }
+
+  private volatile static Long start;
+
+  private static void consensusFollower(PlaceManager placeList) {
+    start = System.nanoTime();
+    new Thread() {
+
+      public void run() {
+        while ((Long) System.nanoTime() - start < 10000000000L) {
+          try {
+            // Gets message and splits it on ","
+            String[] message = placeList.listenUnicastMessage(placeList.getServerPort()).split(",");
+
+            if (message[0].equals("leader")) {
+              // Resets timer
+              start = System.nanoTime();
+              // New leader was found before
+              placeList.setRole(ConsensusRole.FOLLOWER);
+            }
+
+            if (message[0].equals("candidate")) {
+              // New candidate received
+              String[] fullAddress = message[1].split(":");
+              String host = fullAddress[0];
+              Integer port = Integer.parseInt(fullAddress[1]);
+              // Sends vote
+              placeList.sendMessage(host, port, "vote,"
+                  + InetAddress.getLocalHost().getHostAddress() + ":" + placeList.getServerPort());
+            }
+
+            if (message[0].equals("exit")) {
+              this.interrupt();
+              return;
+            }
+          } catch (IOException e) {
+            System.out.println(e.getMessage());
+          }
+        }
+
+      }
+    }.start();
+    // Loop happens if we in the first 10s
+    while ((Long) System.nanoTime() - start < 10000000000L) {
+
+    }
+    try {
+      placeList.sendMessage(InetAddress.getLocalHost().getHostAddress(), placeList.getServerPort(),
+          "exit,");
+    } catch (IOException e) {
+      System.out.println(e.getMessage());
+    }
+    // Becomes candidate
+    placeList.setRole(ConsensusRole.CANDIDATE);
   }
 }

--- a/src/places/PlaceManager.java
+++ b/src/places/PlaceManager.java
@@ -8,9 +8,11 @@ import java.net.MulticastSocket;
 import java.rmi.RemoteException;
 import java.rmi.server.UnicastRemoteObject;
 import java.util.ArrayList;
-import comunication.UDPInterface;
+import comunication.ComunicationInterface;
+import consensus.ConsensusRole;
 
-public class PlaceManager extends UnicastRemoteObject implements PlacesListInterface, UDPInterface {
+public class PlaceManager extends UnicastRemoteObject
+    implements PlacesListInterface, ReplicasManagerInterface, ComunicationInterface {
   /**
    * 
    */
@@ -20,6 +22,7 @@ public class PlaceManager extends UnicastRemoteObject implements PlacesListInter
    */
   private ArrayList<Place> places = new ArrayList<Place>();
   private ArrayList<String> replicas = new ArrayList<String>();
+  private ConsensusRole role;
   private Integer serverPort;
 
   /*
@@ -27,6 +30,32 @@ public class PlaceManager extends UnicastRemoteObject implements PlacesListInter
    */
   public PlaceManager(Integer serverPort) throws RemoteException {
     super(0);
+    this.serverPort = serverPort;
+    this.role = ConsensusRole.FOLLOWER;
+  }
+
+  // Getters & Setters
+  public synchronized ConsensusRole getRole() {
+    return role;
+  }
+
+  public synchronized void setRole(ConsensusRole role) {
+    this.role = role;
+  }
+
+  public synchronized ArrayList<String> getReplicas() {
+    return replicas;
+  }
+
+  public synchronized void setReplicas(ArrayList<String> replicas) {
+    this.replicas = replicas;
+  }
+
+  public Integer getServerPort() {
+    return serverPort;
+  }
+
+  public void setServerPort(Integer serverPort) {
     this.serverPort = serverPort;
   }
 
@@ -68,7 +97,46 @@ public class PlaceManager extends UnicastRemoteObject implements PlacesListInter
   }
 
   /*
-   * Sends a multicast message
+   * Adds a replica address to the arrayList of replicas
+   * 
+   * @param replicaAddress: contains String with address (ip+port)
+   */
+  @Override
+  public synchronized void addReplica(String replicaAddress) throws RemoteException {
+    replicas.add(replicaAddress);
+  }
+
+  /*
+   * Removes a replica address from the arrayList of replicas
+   * 
+   * @param replicaAddress: contains String with address (ip+port)
+   */
+  @Override
+  public synchronized void removeReplica(String replicaAddress) throws RemoteException {
+    replicas.remove(replicaAddress);
+  }
+
+  /*
+   * Adds all replicas from an arrayList to the class arrayList of replicas
+   * 
+   * @param replicas: contains arrayList with all replicas
+   */
+  @Override
+  public synchronized void addAllReplicas(ArrayList<String> replicas) throws RemoteException {
+    this.replicas = replicas;
+  }
+
+  /*
+   * Clears class arrayList of replicas
+   * 
+   */
+  @Override
+  public synchronized void removeAllReplicas() throws RemoteException {
+    replicas.clear();
+  }
+
+  /*
+   * Sends a udp message
    * 
    * @param address: contains String with address
    * 
@@ -93,42 +161,58 @@ public class PlaceManager extends UnicastRemoteObject implements PlacesListInter
   }
 
   /*
-   * Listens to MulticastMessages on given address and port. When a message is received, processes
-   * that message and sends a message with their own ip. Every
+   * Listens to MulticastMessages on given address and port. that message.
    * 
    * @param address: contains String with address
    * 
    * @param port: contains Integer with port
    * 
+   * @return: String with message
    */
   @Override
-  public void listenNewHosts(String address, Integer port) throws IOException {
-    while (true) {
-      // Joins multicast socket
-      MulticastSocket mSocket = new MulticastSocket(port);
-      InetAddress mcAddress = InetAddress.getByName(address);
-      mSocket.joinGroup(mcAddress);
-      
-      // Waits for new messages
-      byte[] buffer = new byte[1024];
-      DatagramPacket message = new DatagramPacket(buffer, buffer.length);
-      mSocket.receive(message);
+  public String listenMulticastMessage(String address, Integer port) throws IOException {
+    // Joins multicast socket
+    MulticastSocket mSocket = new MulticastSocket(port);
+    InetAddress mcAddress = InetAddress.getByName(address);
+    mSocket.joinGroup(mcAddress);
 
-      // Processes new messages
-      String response = new String(message.getData());
-      processMessages(response);
-      
-      // Closes socket
-      mSocket.close();
-    }
+    // Waits for new messages
+    byte[] buffer = new byte[1024];
+    DatagramPacket datagram = new DatagramPacket(buffer, buffer.length);
+
+    mSocket.receive(datagram);
+
+    // Closes socket
+    mSocket.close();
+
+    return new String(datagram.getData(), 0, datagram.getLength());
   }
 
-  private void processMessages(String message) {
-    if (replicas.contains(message)) {
-      return;
-    }
+  /*
+   * Listens to UnicastMessages on given address and port. When a message is received, processes
+   * that message.
+   * 
+   * @param address: contains String with address
+   * 
+   * @param port: contains Integer with port
+   * 
+   * @return: String with message
+   */
+  @Override
+  public String listenUnicastMessage(Integer port) throws IOException {
+    // Creates a "listen" socket on given port
+    DatagramSocket socket = new DatagramSocket(port);
 
-    System.out.println("Adicionei " + message);
-    replicas.add(message);
+    byte[] buffer = new byte[1024];
+    // Prepares datagram packet to be written on given buffer
+    DatagramPacket datagram = new DatagramPacket(buffer, buffer.length);
+
+    // Receives datagram
+    socket.receive(datagram);
+
+    // Closes socket
+    socket.close();
+
+    return new String(datagram.getData(), 0, datagram.getLength());
   }
 }

--- a/src/places/ReplicasManagerInterface.java
+++ b/src/places/ReplicasManagerInterface.java
@@ -1,0 +1,12 @@
+package places;
+
+import java.rmi.Remote;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+
+public interface ReplicasManagerInterface extends Remote {
+  void addReplica(String replicaAddress) throws RemoteException;
+  void removeReplica(String replicaAddress) throws RemoteException;
+  void addAllReplicas(ArrayList<String> replicas) throws RemoteException;
+  void removeAllReplicas() throws RemoteException;
+}


### PR DESCRIPTION
Refers to #5

Changed UDPInterface to ComunicationInterface, since it's a better name.

Added ConsensusRole that defines the state of a replica into 3 categories: FOLLOWER, CANDIDATE, LEADER.

RMIServer.java handles most of the consensus mechanism. It isn't a pretty solution, but it works.

ReplicasManagerInterface was added to handle everything related to the replicas address storage. It can be called via RMI if needed.

Implemented missing interfaces on PlaceManager and, added synchronized methods to everything related to replicas memory access.